### PR TITLE
Add note that repo has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## ⚠ ️This repository has been moved ⚠
+
+`redhat-codeready-dependency-analysis` has been moved to the [`redhat-actions`](https://github.com/redhat-actions) org, and repurposed as [`crda`](https://github.com/redhat-actions/crda).
+
+This repository remains to prevent breaking existing workflows, but will no longer be maintained.
+
 # `redhat-codeready-dependency-analysis`
 
 ## Overview


### PR DESCRIPTION
Since we have released [CRDA GitHub Action](https://github.com/marketplace/actions/codeready-dependency-analytics) on the marketplace with many more new features, therefore adding a note here so that existing users can find new action.
It will be good if we can mark this repository as `archived` so that it's clear that no maintenance will be performed, also remove this action from the marketplace, to get new users to the updated action.

/cc @jparsai 